### PR TITLE
Change x-frame-options obsoletes wording

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3677,7 +3677,7 @@ Content-Type: application/reports+json
   header's \``DENY`\`, and `'self'` to that header's \``SAMEORIGIN`\`. [[!HTML]]
 
   In order to allow backwards-compatible deployment, the
-  <a>`frame-ancestors`</a> directive <em>supersedes</em> the
+  <a>`frame-ancestors`</a> directive <em>overrides</em> the
   \`<code>[:X-Frame-Options:]</code>\` header. If a resource is delivered with
   a <a for="/">policy</a> that includes a <a>directive</a> named
   <a>`frame-ancestors`</a> and whose <a for="policy">disposition</a> is

--- a/index.bs
+++ b/index.bs
@@ -3677,7 +3677,7 @@ Content-Type: application/reports+json
   header's \``DENY`\`, and `'self'` to that header's \``SAMEORIGIN`\`. [[!HTML]]
 
   In order to allow backwards-compatible deployment, the
-  <a>`frame-ancestors`</a> directive <em>obsoletes</em> the
+  <a>`frame-ancestors`</a> directive <em>supersedes</em> the
   \`<code>[:X-Frame-Options:]</code>\` header. If a resource is delivered with
   a <a for="/">policy</a> that includes a <a>directive</a> named
   <a>`frame-ancestors`</a> and whose <a for="policy">disposition</a> is


### PR DESCRIPTION
As discussed at https://github.com/whatwg/html/issues/10936#issuecomment-2604422113 "obsoletes" seems to be being misconstrued to mean X-Frame-Options should no longer be used when that was not the intent.

So I'm suggesting "overrides" as a better word? Or could go with "supplants" or "supersedes" (though they may have same issue as "obsoletes")?